### PR TITLE
making sure redirect-to-login page always generate html

### DIFF
--- a/awful.scm
+++ b/awful.scm
@@ -758,15 +758,16 @@
     ((page-exception-message) exn)))
 
 (define-inline (redirect-to-login-page path)
-  ((page-template)
-   ""
-   headers: (<meta> http-equiv: "refresh"
-                    content: (++ "0;url=" (login-page-path)
-                                 "?reason=invalid-session&attempted-path=" path
-                                 "&user=" ($ 'user "")
-                                 (if (and (not (enable-session-cookie)) ($ 'sid))
-                                     (++ "&sid=" ($ 'sid))
-                                     "")))))
+  (let ((content ((page-template)
+                    ""
+                    headers: (<meta> http-equiv: "refresh"
+                                     content: (++ "0;url=" (login-page-path)
+                                                  "?reason=invalid-session&attempted-path=" path
+                                                  "&user=" ($ 'user "")
+                                                  (if (and (not (enable-session-cookie)) ($ 'sid))
+                                                    (++ "&sid=" ($ 'sid))
+                                                    ""))))))
+    (if sxml? ((sxml->html) content) content)))
 
 (define-inline (render-page contents path given-path no-javascript-compression ajax? sxml?)
   (let ((++* (if sxml? (lambda args (apply append (map list args))) ++))


### PR DESCRIPTION
Hi Mario,

here is a testcase: https://gist.github.com/hugoArregui/5988834 

I'm not sure if this is the right fix, as I don't understand why the error is not triggered when I comment out the #5 line. However, this change seems aligned to the rest of the code, so I made this pull request. 

HIH
