### PR TITLE
ajax: allow using success with target/update-targets

### DIFF
--- a/awful.scm
+++ b/awful.scm
@@ -1053,7 +1053,9 @@
                      (conc "contentType: '" content-type "',")
                      "")
                  "success:function(response){"
-                 (or success
+                 (string-append
+                     (or success "")
+                     ";"
                      (cond (update-targets
                             "$.each(response, function(id, html) { $('#' + id).html(html);});")
                            (target


### PR DESCRIPTION
The `success`, `target`, and `update-targets` features of the `ajax` function decide what needs to be done with a response from an ajax request. The `update-targets` feature, in particular, in addition to conveying the semantics of what it does much better than the one-liner it injects, it also arranges for the response to be provided as a JSON object.

However, `success` and the `target`/`update-targets` features are currently mutually exclusive.

This PR proposes to allow both features to be used together.

I have decided to run `success` first, if specified, so in an extreme case one can also `return` in it and skip the `target`/`update-targets` part.

If this PR is accepted, I am willing to update the corresponding docs.